### PR TITLE
fix: limit scoreboard to top 100

### DIFF
--- a/app/pages/api/scoreboard.ts
+++ b/app/pages/api/scoreboard.ts
@@ -66,7 +66,7 @@ export default async function handler(
   const numTippers = users.filter((user) => user.tipsSent.length > 0).length;
 
   const scoreboard: Scoreboard = {
-    entries,
+    entries: entries.splice(0, 100),
     numTippers,
     numUsersOnboarded,
     numTipsSent: entries.length

--- a/app/pages/api/scoreboard.ts
+++ b/app/pages/api/scoreboard.ts
@@ -66,7 +66,7 @@ export default async function handler(
   const numTippers = users.filter((user) => user.tipsSent.length > 0).length;
 
   const scoreboard: Scoreboard = {
-    entries: entries.splice(0, 100),
+    entries: entries,
     numTippers,
     numUsersOnboarded,
     numTipsSent: entries.length


### PR DESCRIPTION
UI gets quite laggy with 100s of users. Limited users to top 100 for the first step, don't know how easy it would be to add some lazy loading as you scroll down the page? 