### PR TITLE
Fix unique key prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .DS_Store
+
+# ignore local Webstorm IDE settings
+.idea

--- a/app/components/Login.tsx
+++ b/app/components/Login.tsx
@@ -57,7 +57,7 @@ export function Login({
           .filter((method) => method !== loginMethod)
           .map((method, i) => {
             return (
-              <React.Fragment key={i}>
+              <React.Fragment key={method}>
                 <Button
                   light
                   auto

--- a/app/components/Login.tsx
+++ b/app/components/Login.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Button, Row, Spacer, Text } from "@nextui-org/react";
 import { useTranslation } from "next-i18next";
 import EmailSignIn from "pages/auth/signin/email";
@@ -56,7 +57,7 @@ export function Login({
           .filter((method) => method !== loginMethod)
           .map((method, i) => {
             return (
-              <>
+              <React.Fragment key={i}>
                 <Button
                   light
                   auto
@@ -67,7 +68,7 @@ export function Login({
                   {t(`common:${method}`)}
                 </Button>
                 {i === 0 && <Text>&nbsp;{t("common:or")}&nbsp;</Text>}
-              </>
+              </React.Fragment>
             );
           })}
         <Text>&nbsp; {t("login:instead")}</Text>


### PR DESCRIPTION
This is a minor fix only, but I always feel kind of annoyed by spammed console outputs. Maybe other people feel the same.
It removes the "Warning: Each child in a list should have a unique "key" prop." from the console.log. 

I also tried to fix the "Warning: Prop `className` did not match. Server: " but was not successful.