### PR TITLE
Fix/link to used account

### DIFF
--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -44,7 +44,7 @@ export const authOptions: NextAuthOptions = {
         });
 
         // let's check if this account is already in use
-        let lnAccountUser = await prisma.user.findUnique({
+        const lnAccountUser = await prisma.user.findUnique({
           where: {
             lnurlPublicKey: authKey.key,
           },

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -64,7 +64,9 @@ export const authOptions: NextAuthOptions = {
           });
 
           if (!user) {
-            throw new Error("User to link does not exist: " + authKey.linkUserId);
+            throw new Error(
+              "User to link does not exist: " + authKey.linkUserId
+            );
           }
 
           await prisma.user.update({
@@ -75,7 +77,6 @@ export const authOptions: NextAuthOptions = {
               lnurlPublicKey: authKey.key,
             },
           });
-
         } else {
           user = await prisma.user.create({
             data: {

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -51,7 +51,7 @@ export const authOptions: NextAuthOptions = {
         });
 
         if (lnAccountUser) {
-          throw new Error("ln_account_not_unique");
+          throw new Error("link_account_not_unique");
         }
 
         let user;

--- a/app/pages/auth/signin/lnurl.tsx
+++ b/app/pages/auth/signin/lnurl.tsx
@@ -107,10 +107,10 @@ export default function LnurlAuthSignIn({ callbackUrl }: LnurlAuthSignInProps) {
   const handleSignInError = (error) => {
     console.error(error);
 
-    let message = "Unexpected login result: " + error?.message;
+    let message = t("login:login_error_default_prefix") + error?.message;
 
-    if (error?.message === "ln_account_not_unique") {
-      message = "This Lightning account is already used by a different user.";
+    if (error?.message === "link_account_not_unique") {
+      message = t("login:link_account_not_unique");
       router.push("/profile");
     }
 

--- a/app/pages/auth/signin/lnurl.tsx
+++ b/app/pages/auth/signin/lnurl.tsx
@@ -86,11 +86,25 @@ export default function LnurlAuthSignIn({ callbackUrl }: LnurlAuthSignInProps) {
             throw new Error(result?.error);
           }
         } catch (error) {
-          handleSignInError(error);
+          console.error(error);
+
+          let message;
+          if (error instanceof Error) {
+            if (error?.message === "link_account_not_unique") {
+              message = t("login:link_account_not_unique");
+              router.push("/profile");
+            } else {
+              message = t("login:login_error_default_prefix") + error?.message;
+            }
+          } else {
+            message = t("login:login_error_default");
+          }
+
+          toast.error(message);
         }
       })();
     }
-  }, [callbackUrlWithFallback, qr, router, status]);
+  }, [callbackUrlWithFallback, qr, router, status, t]);
 
   const copyQr = React.useCallback(() => {
     if (qr) {
@@ -103,19 +117,6 @@ export default function LnurlAuthSignIn({ callbackUrl }: LnurlAuthSignInProps) {
     () => ({ lnurlAuthCapable: true, filterOtherItems: true, shadow: false }),
     []
   );
-
-  const handleSignInError = (error) => {
-    console.error(error);
-
-    let message = t("login:login_error_default_prefix") + error?.message;
-
-    if (error?.message === "link_account_not_unique") {
-      message = t("login:link_account_not_unique");
-      router.push("/profile");
-    }
-
-    toast.error(message);
-  }
 
   return (
     <>

--- a/app/pages/auth/signin/lnurl.tsx
+++ b/app/pages/auth/signin/lnurl.tsx
@@ -83,11 +83,10 @@ export default function LnurlAuthSignIn({ callbackUrl }: LnurlAuthSignInProps) {
           if (result && result.ok && result.url) {
             router.push(result.url);
           } else {
-            throw new Error("Unexpected login result: " + result?.error);
+            throw new Error(result?.error);
           }
         } catch (error) {
-          console.error(error);
-          toast.error("login failed");
+          handleSignInError(error);
         }
       })();
     }
@@ -104,6 +103,19 @@ export default function LnurlAuthSignIn({ callbackUrl }: LnurlAuthSignInProps) {
     () => ({ lnurlAuthCapable: true, filterOtherItems: true, shadow: false }),
     []
   );
+
+  const handleSignInError = (error) => {
+    console.error(error);
+
+    let message = "Unexpected login result: " + error?.message;
+
+    if (error?.message === "ln_account_not_unique") {
+      message = "This Lightning account is already used by a different user.";
+      router.push("/profile");
+    }
+
+    toast.error(message);
+  }
 
   return (
     <>

--- a/app/public/locales/en/login.json
+++ b/app/public/locales/en/login.json
@@ -5,5 +5,7 @@
     "scanQrCode": "Scan this code or copy and paste it to your Lightning wallet. Or click to log in with your web browser's wallet.",
     "clickToConnect": "Click to connect",
     "use": "Use",
-    "instead": "instead"
+    "instead": "instead",
+    "link_account_not_unique": "This Lightning account is already used by a different user.",
+    "login_error_default_prefix": "Unexpected login result: "
 }

--- a/app/public/locales/en/login.json
+++ b/app/public/locales/en/login.json
@@ -7,5 +7,6 @@
     "use": "Use",
     "instead": "instead",
     "link_account_not_unique": "This Lightning account is already used by a different user.",
-    "login_error_default_prefix": "Unexpected login result: "
+    "login_error_default_prefix": "Unexpected login result: ",
+    "login_error_default": "Login failed."
 }


### PR DESCRIPTION
Fix #146 

This fix works, not sure if it's the ideal solution.

What bugs me a little bit is, clicking the "Click to connect" button on the "/auth/signin/lnurl" page we don't know which account it's gonna be yet, as it is determined within the Alby extension. For this reason we can only check after a succesful login. So the result is, first the browser LN login success message notification shows up, then the lightsats website error toast informs about the linking/auth of the account failed, as it is already in use. But don't really know how to improve this.