### PR TITLE
Sort languages on alphabetical order

### DIFF
--- a/app/next-i18next.config.js
+++ b/app/next-i18next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "th", "pt-BR", "de", "es", "fr", "nb", "ar"],
+    locales: ["de", "en", "es", "fr", "nb", "pt-BR", "ar", "th"]
   },
   reloadOnPrerender: process.env.NEXT_PUBLIC_RELOAD_I18N === "true",
 };


### PR DESCRIPTION
- Languages will now show in alphabetical order based on the full locale 
- Arabic and Thai are last in the list as these don't use the Latin alphabet

I don't know where 'Deutsch' and 'francais' are pulled from, as this could be improved as well in terms of lower/upper-casing.
![image](https://github.com/lightsats/lightsats/assets/3382304/943e3966-db1e-492d-a223-3aa5ada008fc)